### PR TITLE
Add jsx to dependent applications

### DIFF
--- a/src/jwerl.app.src
+++ b/src/jwerl.app.src
@@ -3,7 +3,7 @@
   , {vsn, "0.1.1"}
   , {registered, []}
   , {modules, []}
-  , {applications, [kernel, stdlib]}
+  , {applications, [kernel, stdlib, jsx]}
   , {env, []}
 
   , {maintainers, ["Gregoire Lejeune"]}


### PR DESCRIPTION
When `jwerl` is used as a dep and the main project doesn't depend on `jsx`, `jsx` is not added to the release.
This leads to runtime `undef` errors.