### PR TITLE
Inspect header parameters + JWT claims before validation

### DIFF
--- a/src/jwerl.erl
+++ b/src/jwerl.erl
@@ -1,7 +1,8 @@
 -module(jwerl).
 
 -export([sign/1, sign/2,
-         verify/1, verify/2]).
+         verify/1, verify/2,
+         payload/1]).
 
 -define(DEFAULT_ALG, <<"HS256">>).
 -define(DEFAULT_HEADER, #{typ => <<"JWT">>,
@@ -29,6 +30,9 @@ verify(Data, Options) ->
     Result ->
       Result
   end.
+
+payload(Data) ->
+    payload(Data, none, none).
 
 check_claims(TokenData) ->
   Now = os:system_time(seconds),

--- a/src/jwerl.erl
+++ b/src/jwerl.erl
@@ -2,7 +2,7 @@
 
 -export([sign/1, sign/2,
          verify/1, verify/2,
-         payload/1]).
+         payload/1, header/1]).
 
 -define(DEFAULT_ALG, <<"HS256">>).
 -define(DEFAULT_HEADER, #{typ => <<"JWT">>,
@@ -32,7 +32,11 @@ verify(Data, Options) ->
   end.
 
 payload(Data) ->
-  payload(Data, none, none).
+  {ok, P} = payload(Data, none, none),
+  P.
+
+header(Data) ->
+  decode_header(Data).
 
 check_claims(TokenData) ->
   Now = os:system_time(seconds),

--- a/src/jwerl.erl
+++ b/src/jwerl.erl
@@ -32,7 +32,7 @@ verify(Data, Options) ->
   end.
 
 payload(Data) ->
-    payload(Data, none, none).
+  payload(Data, none, none).
 
 check_claims(TokenData) ->
   Now = os:system_time(seconds),
@@ -100,7 +100,7 @@ urldecode_digit($-) -> $+;
 urldecode_digit(D)  -> D.
 
 config_headers(Options) ->
-  maps:merge(?DEFAULT_HEADER, #{alg => maps:get(alg, Options, ?DEFAULT_ALG)}).
+  maps:merge(?DEFAULT_HEADER, Options).
 
 decode_header(Data) ->
   [Header|_] = binary:split(Data, <<".">>, [global]),

--- a/test/jwerl_tests.erl
+++ b/test/jwerl_tests.erl
@@ -13,7 +13,8 @@ jwerl_test_() ->
     ?_test(t_jwerl_rsa()),
     ?_test(t_jwerl_ecdsa()),
     ?_test(t_jwerl_no_claims()),
-    ?_test(t_jwerl_claims())
+    ?_test(t_jwerl_claims()),
+    ?_test(t_jwerl_payload())
    ]}.
 
 setup() ->
@@ -104,6 +105,10 @@ t_jwerl_claims() ->
   ?assertMatch({error, not_yet_valid}, jwerl:verify(
                                    jwerl:sign(Data4, #{alg => none}),
                                    #{alg => none})).
+
+t_jwerl_payload() ->
+  Data = #{key => <<"value">>},
+  ?assertMatch({ok, Data}, jwerl:payload(jwerl:sign(Data))).
 
 rsa_private_key() ->
   % openssl genrsa -out private_key.pem 4096

--- a/test/jwerl_tests.erl
+++ b/test/jwerl_tests.erl
@@ -14,7 +14,8 @@ jwerl_test_() ->
     ?_test(t_jwerl_ecdsa()),
     ?_test(t_jwerl_no_claims()),
     ?_test(t_jwerl_claims()),
-    ?_test(t_jwerl_payload())
+    ?_test(t_jwerl_payload()),
+    ?_test(t_jwerl_header())
    ]}.
 
 setup() ->
@@ -108,7 +109,12 @@ t_jwerl_claims() ->
 
 t_jwerl_payload() ->
   Data = #{key => <<"value">>},
-  ?assertMatch({ok, Data}, jwerl:payload(jwerl:sign(Data))).
+  ?assertMatch(Data, jwerl:payload(jwerl:sign(Data))).
+
+t_jwerl_header() ->
+  Data = #{key => <<"value">>},
+  DefaultHeader = #{typ => <<"JWT">>, alg => <<"HS256">>},
+  ?assertMatch(DefaultHeader, jwerl:header(jwerl:sign(Data))).
 
 rsa_private_key() ->
   % openssl genrsa -out private_key.pem 4096


### PR DESCRIPTION
This introduces two procedures (along with tests) for the above. Section [7.2. Validating a JWT](https://tools.ietf.org/html/rfc7519#section-7.2) in the RFC writes:

> The order of the steps is not significant in cases where there are no dependencies between the inputs and outputs of the steps.

To keep JWT encoding consistent with decoding, since we can now inspect the header before validation, this PR allows any selection of header parameters to be put in the header (not just the `alg` parameter).