### PR TITLE
Stop atom leak from decoded JWT JSON keys

### DIFF
--- a/src/jwerl.erl
+++ b/src/jwerl.erl
@@ -4,6 +4,8 @@
          verify/1, verify/2,
          payload/1, header/1]).
 
+-on_load(conveniece_keys/0).
+
 -define(DEFAULT_ALG, <<"HS256">>).
 -define(DEFAULT_HEADER, #{typ => <<"JWT">>,
                           alg => ?DEFAULT_ALG}).
@@ -108,11 +110,11 @@ config_headers(Options) ->
 
 decode_header(Data) ->
   [Header|_] = binary:split(Data, <<".">>, [global]),
-  jsx:decode(base64_decode(Header), [return_maps, {labels, atom}]).
+  jsx:decode(base64_decode(Header), [return_maps, {labels, attempt_atom}]).
 
 payload(Data, none, _) ->
   [_, Data1|_] = binary:split(Data, <<".">>, [global]),
-  {ok, jsx:decode(base64_decode(Data1), [return_maps, {labels, atom}])};
+  {ok, jsx:decode(base64_decode(Data1), [return_maps, {labels, attempt_atom}])};
 payload(Data, Alg, Key) ->
   [Header, Data1, Signature] = binary:split(Data, <<".">>, [global]),
   {AlgMod, ShaBits} = algorithm_to_infos(Alg),
@@ -121,7 +123,7 @@ payload(Data, Alg, Key) ->
                                      <<Header/binary, ".", Data1/binary>>,
                                      base64_decode(Signature)]) of
     true ->
-      {ok, jsx:decode(base64_decode(Data1), [return_maps, {labels, atom}])};
+      {ok, jsx:decode(base64_decode(Data1), [return_maps, {labels, attempt_atom}])};
     _ ->
       {error, invalid_signature}
   end.
@@ -169,3 +171,25 @@ algorithm_to_infos(Algo) ->
     _ ->
       exit(invalid_algorithme)
   end.
+
+conveniece_keys() ->
+    registered_claim_names(),
+    header_parameters(),
+    miscellaneous(),
+    ok.
+
+registered_claim_names() ->
+    iss,
+    sub,
+    aud,
+    exp,
+    nbf,
+    iat,
+    jti.
+
+header_parameters() ->
+    typ,
+    cty.
+
+miscellaneous() ->
+    alg.

--- a/test/jwerl_tests.erl
+++ b/test/jwerl_tests.erl
@@ -15,7 +15,9 @@ jwerl_test_() ->
     ?_test(t_jwerl_no_claims()),
     ?_test(t_jwerl_claims()),
     ?_test(t_jwerl_payload()),
-    ?_test(t_jwerl_header())
+    ?_test(t_jwerl_header()),
+    ?_test(t_jwerl_registered_claim_name()),
+    ?_test(t_jwerl_not_registered_claim_name())
    ]}.
 
 setup() ->
@@ -115,6 +117,16 @@ t_jwerl_header() ->
   Data = #{key => <<"value">>},
   DefaultHeader = #{typ => <<"JWT">>, alg => <<"HS256">>},
   ?assertMatch(DefaultHeader, jwerl:header(jwerl:sign(Data))).
+
+t_jwerl_registered_claim_name() ->
+    In = #{<<"sub">> => <<"s">>},
+    Out = #{sub => <<"s">>},
+    ?assertMatch({ok, Out}, jwerl:verify(jwerl:sign(In))).
+
+t_jwerl_not_registered_claim_name() ->
+    Data = #{<<"planet">> => <<"zorg">>},
+    ?assertMatch({ok, Data}, jwerl:verify(jwerl:sign(Data))).
+
 
 rsa_private_key() ->
   % openssl genrsa -out private_key.pem 4096


### PR DESCRIPTION
Decoding JWT JSON keys into atoms could be exploited maliciously. This PR attempts to keep almost all the old behaviour within reasonable limits. I.e. common JWT claims and keys will still be decoded into (existing) atoms but private or personal claims will be decoded into binaries. The `key` atom and `<<"key">>`, in the test suite, will decode into the `key` atom as it exists in the test suite and indeed in `jwerl.erl`.