### PR TITLE
Update jsx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2015, 2016, 2017 G-Corp
 
-__Version:__ 0.1.0
+__Version:__ 0.2.0
 
 __Authors:__ Gregoire Lejeune ([`gregoire.lejeune@gmail.com`](mailto:gregoire.lejeune@gmail.com)).
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2015, 2016, 2017 G-Corp
 
-__Version:__ 0.1.0
+__Version:__ 0.2.0
 
 __Authors:__ Gregoire Lejeune ([`gregoire.lejeune@gmail.com`](mailto:gregoire.lejeune@gmail.com)).
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Jwerl.Mixfile do
   def project do
     [
       app: :jwerl,
-      version: "0.1.3",
+      version: "0.2.0",
       elixir: "~> 1.2",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Jwerl.Mixfile do
 
   defp deps do
     [
-      {:jsx, "~> 2.8.2"}
+      {:jsx, "~> 2.9.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [], [], "hexpm"}}
+%{"jsx": {:hex, :jsx, "2.9.0", "d2f6e5f069c00266cad52fb15d87c428579ea4d7d73a33669e12679e203329dd", [], [], "hexpm"}}

--- a/overview.edoc
+++ b/overview.edoc
@@ -1,6 +1,6 @@
 @author Gregoire Lejeune <gregoire.lejeune@gmail.com>
 @copyright 2015, 2016, 2017 G-Corp
-@version 0.1.0
+@version 0.2.0
 @title JWErl
 @doc
 

--- a/src/jwerl.app.src
+++ b/src/jwerl.app.src
@@ -1,6 +1,6 @@
 {application, jwerl, [
   {description, "JWT Library for Erlang and Elixir"}
-  , {vsn, "0.1.3"}
+  , {vsn, "0.2.0"}
   , {registered, []}
   , {modules, []}
   , {applications, [kernel, stdlib, jsx]}


### PR DESCRIPTION
This PR updates the `jsx` dependency to version `2.9.0` (latest). 