### PR TITLE
Add leeway tolerance for exp claim validation

### DIFF
--- a/src/jwerl.erl
+++ b/src/jwerl.erl
@@ -104,7 +104,8 @@ check_claims(TokenData, Claims, Opts) ->
   claims_errors(
     [
      check_claim(TokenData, exp, false, fun(ExpireTime) ->
-                                            Now < ExpireTime
+                                            ExpLeeway = maps:get(exp_leeway, Opts, 0),
+                                            Now < ExpireTime + ExpLeeway
                                         end, exp),
      check_claim(TokenData, iat, false, fun(IssuedAt) ->
                                             IatLeeway = maps:get(iat_leeway, Opts, 0),

--- a/test/jwerl_tests.erl
+++ b/test/jwerl_tests.erl
@@ -40,7 +40,15 @@ t_jwerl_leeway() ->
     Data2 = #{key => <<"value">>, exp => Now + 1000, nbf => Now, iat => IssuedAtWithClockSkew2},
     ?assertMatch({ok, Data2}, jwerl:verify(
                                 jwerl:sign(Data2, none),
-                                none, <<"">>, #{}, #{iat_leeway => 250})).
+                                none, <<"">>, #{}, #{iat_leeway => 250})),
+    Data3 = #{key => <<"value">>, exp => Now - 500, nbf => Now, iat => Now },
+    ?assertMatch({error, [exp]}, jwerl:verify(
+                                jwerl:sign(Data3, none),
+                                none, <<"">>, #{}, #{exp_leeway => 250})),
+    Data4 = #{key => <<"value">>, exp => Now - 200, nbf => Now, iat => Now },
+    ?assertMatch({ok, Data4}, jwerl:verify(
+                                jwerl:sign(Data4, none),
+                                none, <<"">>, #{}, #{exp_leeway => 250})).
 
 t_jwerl_default() ->
   Data = #{key => <<"value">>},


### PR DESCRIPTION
In order to tolerate clock skews between JWT signing and verification we need to have a leeway parameter for exp claim validation.