### PR TITLE
Use crypto:mac/4 instead of hmac/3

### DIFF
--- a/src/jwerl_hs.erl
+++ b/src/jwerl_hs.erl
@@ -4,7 +4,7 @@
 -export([sign/3, verify/4]).
 
 sign(ShaBits, Key, Data) ->
-  crypto:hmac(algo(ShaBits), Key, Data).
+  crypto:mac(hmac, algo(ShaBits), Key, Data).
 
 verify(ShaBits, Key, Data, Signature) ->
   Signature == sign(ShaBits, Key, Data).


### PR DESCRIPTION
## About

`crypto:hmac/3` [was removed](http://erlang.org/doc/general_info/removed.html#functions-removed-in-otp-24) in OTP 24. `crypto:mac/4` should be used instead.